### PR TITLE
Fixed possible invalid status code range error

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ class ExpressOAuthServer {
       res.set(oauthResponse.headers);
     }
 
-    res.status(error.code);
+    res.status(error.code || 500);
 
     if (error instanceof UnauthorizedRequestError) {
       return res.send();


### PR DESCRIPTION
If `error.code` is undefined this can result in a RangeError where the HTTP status code is invalid. This will cause the application to crash swallowing the actual error.